### PR TITLE
fix: prevent possible SQL injection

### DIFF
--- a/src/MVH/mvh_wrapper.php
+++ b/src/MVH/mvh_wrapper.php
@@ -71,7 +71,12 @@ if (!$test)
 {
 	$status = $exit_code==0 ? "done" : "failed";
 	$db_mvh = DB::getInstance("MVH");
-	$hash = $db_mvh->prepare("UPDATE submission_".strtolower($type)." SET status=:status, submission_id=:submission_id, submission_output=:submission_output, date=CURDATE() WHERE id=:id");
+	$submission_type = strtolower($type);
+	if ($submission_type != "grz" || $submission_type != "kdk_se") {
+		print "  Skipped because invalid submission type used\n";
+		return;
+	}
+	$hash = $db_mvh->prepare("UPDATE submission_".$submission_type." SET status=:status, submission_id=:submission_id, submission_output=:submission_output, date=CURDATE() WHERE id=:id");
 	$db_mvh->bind($hash, "status", $status);
 	$db_mvh->bind($hash, "submission_id", $id_sub);
 	$db_mvh->bind($hash, "submission_output", implode("\n", $stdout));


### PR DESCRIPTION
This explicit prevents malicious actions if someone uses submission type strings causing SQL injections.

`$type` should only contain `GRZ` or `KDK_SE` at this point, but it should be checked before db query.